### PR TITLE
Welch PSD options

### DIFF
--- a/examples/spectrumMeasure.py
+++ b/examples/spectrumMeasure.py
@@ -30,11 +30,12 @@ signalOut, signalIn = daq.readwrite(white, ["AI0", "AI1"], "AO0")
 
 # Create Bode() instance and extract transfer function
 bode = Bode(daq.samplerate, signalOut, signalIn)
-freqs, H = bode.getTransfer(nperseg=int(white.size / 10))
+freqs, H = bode.getTransfer(nperseg=int(white.size / 50))
 
 # Plot transfer function
 plotBode(2*np.pi*freqs, np.abs(H), np.angle(H), 
-         xlim=(1, 1e5))
+         xlim=(10, 5e5), 
+         mag_ylim=(-80, 20))
 
 
 # =============================================================================
@@ -45,7 +46,7 @@ plotBode(2*np.pi*freqs, np.abs(H), np.angle(H),
 # =============================================================================
 
 # Measure over range of frequencies
-freqs = np.logspace(1, 4, 50)
+freqs = np.logspace(1, 5, 50)
 powers = np.zeros_like(freqs)
 phases = np.zeros_like(freqs)
 
@@ -68,4 +69,49 @@ for i, freq in enumerate(tqdm(freqs)):
     phases[i] = phase
 
 # Plot the bode plots
-plotBode(2 * np.pi * freqs, np.sqrt(powers), phases)
+plotBode(2 * np.pi * freqs, np.sqrt(powers), phases,
+         xlim=(10, 5e5), 
+         mag_ylim=(-80, 20))
+
+# =============================================================================
+# = There are two methods to measure the transfer function using SPAN         =
+# = The second method is slow but more accurate, and uses a sweep over        =
+# = different frequencies to determine the transfer function at each          =
+# = frequency individually                                                    =
+# = Here, we are using the `getTranfer` function of SPAN.bode, which          =
+# = returns the Welch power spectrum. We thus have to extract only at         =
+# = those points closest to the frequency of interest.                        =
+# = This and the previous method are equivalent.                              =
+# =============================================================================
+
+
+# Run simulation in the domain [1Hz, 100kHz)
+freqs = np.logspace(1, 5, 50)
+
+# Keep track of (simulated) magnitude and phase
+mags = np.zeros_like(freqs)
+phases = np.zeros_like(freqs)
+
+# Run simulation over range of frequencies
+for i, freq in enumerate(tqdm(freqs)):
+    # Input is simple sine, simulate output
+    timeArray, signalWrite = MyDAQ.generateWaveform("sine", daq.samplerate, frequency=freq)
+    signalOut, signalIn = daq.readwrite(signalWrite, ["AI0", "AI1"], "AO0")
+
+    # Create Bode() instance
+    bode = Bode(daq.samplerate, signalOut, signalIn)
+
+    # Get power and phase of freq, with a bandwidth delta=1
+    Hfreqs, H = bode.getTransfer(nperseg = int(signalIn.size) / 50)
+    index = np.argmin(abs(Hfreqs - freq))
+    
+    mag = abs(H)[index]
+    phase = np.angle(H)[index]
+    # Save power and phase of freq.
+    mags[i] = mag
+    phases[i] = phase
+
+# Plot the bode plots
+plotBode(2 * np.pi * freqs, mags, phases,
+         xlim=(10, 5e5), 
+         mag_ylim=(-80, 20))

--- a/examples/spectrumMeasure.py
+++ b/examples/spectrumMeasure.py
@@ -6,45 +6,66 @@ the Bode() class to extract information for the bode plots
 import numpy as np
 from span.bode import Bode, plotBode
 from span.daq import MyDAQ
+from tqdm import tqdm
 
 # Create daq object
 daq = MyDAQ()
 daq.samplerate = 200_000
-daq.name = "myDAQ"
+daq.name = "myDAQ1"
 print(daq)
 
+# =============================================================================
+# = There are two methods to measure the transfer function using SPAN         =
+# = The first method is quick but less accurate, and uses a white noise       =
+# = spectrum to immediately determine the transfer function                   =
+# =============================================================================
+
+# Duration of measurement
+T = 2
 # Generate array of white noise
-timeArray, white = daq.generateWaveform("white", daq.samplerate, frequency=1)
+timeArray, white = daq.generateWaveform("white", daq.samplerate, frequency=1, duration=T)
 
 # Write to channel AO0, read on channel AI0, AI1
 signalOut, signalIn = daq.readwrite(white, ["AI0", "AI1"], "AO0")
 
-# Create Bode() instance
+# Create Bode() instance and extract transfer function
 bode = Bode(daq.samplerate, signalOut, signalIn)
-freqs, welchIn, welchOut = bode.getWelchSpectrum()
+freqs, H = bode.getTransfer(nperseg=int(white.size / 10))
 
-plotBode(2 * np.pi * freqs, welchOut, np.zeros_like(welchOut))
+# Plot transfer function
+plotBode(2*np.pi*freqs, np.abs(H), np.angle(H), 
+         xlim=(1, 1e5))
+
+
+# =============================================================================
+# = There are two methods to measure the transfer function using SPAN         =
+# = The second method is slow but more accurate, and uses a sweep over        =
+# = different frequencies to determine the transfer function at each          =
+# = frequency individually                                                    =
+# =============================================================================
 
 # Measure over range of frequencies
-# for i, freq in enumerate(freqs):
-#     print(freq)
-# 
-#     # Create sinusoidal waveform
-#     timeArray, signalWrite = daq.generateWaveform("sine", daq.samplerate, frequency=freq)
-# 
-#     # Write to channel AO0 and read on channel AI0
-#     signalOut, signalIn = daq.readwrite(signalWrite, ["AI0", "AI1"], "AO0")
-# 
-#     # Create Bode() instance
-#     bode = Bode(daq.samplerate, signalOut, signalIn)
-# 
-#     # Get power and phase of freq, with a bandwidth delta=1
-#     power = bode.getPower(freq, 1)
-#     phase = bode.getPhase(freq, 0)
-# 
-#     # Save power and phase of freq.
-#     powers[i] = power
-#     phases[i] = phase
-# 
-# # Plot the bode plots
-# plotBode(2 * np.pi * freqs, np.sqrt(powers), phases)
+freqs = np.logspace(1, 4, 50)
+powers = np.zeros_like(freqs)
+phases = np.zeros_like(freqs)
+
+for i, freq in enumerate(tqdm(freqs)):
+    # Create sinusoidal waveform
+    timeArray, signalWrite = daq.generateWaveform("sine", daq.samplerate, frequency=freq)
+
+    # Write to channel AO0 and read on channel AI0
+    signalOut, signalIn = daq.readwrite(signalWrite, ["AI0", "AI1"], "AO0")
+
+    # Create Bode() instance
+    bode = Bode(daq.samplerate, signalOut, signalIn)
+
+    # Get power and phase of freq, with a bandwidth delta=1
+    power = bode.getPower(freq, 1)
+    phase = bode.getPhase(freq, 0)
+
+    # Save power and phase of freq.
+    powers[i] = power
+    phases[i] = phase
+
+# Plot the bode plots
+plotBode(2 * np.pi * freqs, np.sqrt(powers), phases)

--- a/examples/spectrumMeasure.py
+++ b/examples/spectrumMeasure.py
@@ -23,7 +23,9 @@ print(daq)
 # Duration of measurement
 T = 2
 # Generate array of white noise
-timeArray, white = daq.generateWaveform("white", daq.samplerate, frequency=1, duration=T)
+timeArray, white = daq.generateWaveform(
+    "white", daq.samplerate, frequency=1, duration=T
+)
 
 # Write to channel AO0, read on channel AI0, AI1
 signalOut, signalIn = daq.readwrite(white, ["AI0", "AI1"], "AO0")
@@ -33,9 +35,7 @@ bode = Bode(daq.samplerate, signalOut, signalIn)
 freqs, H = bode.getTransfer(nperseg=int(white.size / 50))
 
 # Plot transfer function
-plotBode(2*np.pi*freqs, np.abs(H), np.angle(H), 
-         xlim=(10, 5e5), 
-         mag_ylim=(-80, 20))
+plotBode(2 * np.pi * freqs, np.abs(H), np.angle(H), xlim=(10, 5e5), mag_ylim=(-80, 20))
 
 
 # =============================================================================
@@ -52,7 +52,9 @@ phases = np.zeros_like(freqs)
 
 for i, freq in enumerate(tqdm(freqs)):
     # Create sinusoidal waveform
-    timeArray, signalWrite = daq.generateWaveform("sine", daq.samplerate, frequency=freq)
+    timeArray, signalWrite = daq.generateWaveform(
+        "sine", daq.samplerate, frequency=freq
+    )
 
     # Write to channel AO0 and read on channel AI0
     signalOut, signalIn = daq.readwrite(signalWrite, ["AI0", "AI1"], "AO0")
@@ -69,9 +71,7 @@ for i, freq in enumerate(tqdm(freqs)):
     phases[i] = phase
 
 # Plot the bode plots
-plotBode(2 * np.pi * freqs, np.sqrt(powers), phases,
-         xlim=(10, 5e5), 
-         mag_ylim=(-80, 20))
+plotBode(2 * np.pi * freqs, np.sqrt(powers), phases, xlim=(10, 5e5), mag_ylim=(-80, 20))
 
 # =============================================================================
 # = There are two methods to measure the transfer function using SPAN         =
@@ -95,16 +95,18 @@ phases = np.zeros_like(freqs)
 # Run simulation over range of frequencies
 for i, freq in enumerate(tqdm(freqs)):
     # Input is simple sine, simulate output
-    timeArray, signalWrite = MyDAQ.generateWaveform("sine", daq.samplerate, frequency=freq)
+    timeArray, signalWrite = MyDAQ.generateWaveform(
+        "sine", daq.samplerate, frequency=freq
+    )
     signalOut, signalIn = daq.readwrite(signalWrite, ["AI0", "AI1"], "AO0")
 
     # Create Bode() instance
     bode = Bode(daq.samplerate, signalOut, signalIn)
 
     # Get power and phase of freq, with a bandwidth delta=1
-    Hfreqs, H = bode.getTransfer(nperseg = int(signalIn.size) / 50)
+    Hfreqs, H = bode.getTransfer(nperseg=int(signalIn.size) / 50)
     index = np.argmin(abs(Hfreqs - freq))
-    
+
     mag = abs(H)[index]
     phase = np.angle(H)[index]
     # Save power and phase of freq.
@@ -112,6 +114,4 @@ for i, freq in enumerate(tqdm(freqs)):
     phases[i] = phase
 
 # Plot the bode plots
-plotBode(2 * np.pi * freqs, mags, phases,
-         xlim=(10, 5e5), 
-         mag_ylim=(-80, 20))
+plotBode(2 * np.pi * freqs, mags, phases, xlim=(10, 5e5), mag_ylim=(-80, 20))

--- a/examples/spectrumMeasure.py
+++ b/examples/spectrumMeasure.py
@@ -10,37 +10,41 @@ from span.daq import MyDAQ
 # Create daq object
 daq = MyDAQ()
 daq.samplerate = 200_000
-daq.name = "myDAQ1"
+daq.name = "myDAQ"
 print(daq)
 
-# Do measurement in the domain [1Hz, 100kHz)
-freqs = np.logspace(0, 5, 50)
+# Generate array of white noise
+timeArray, white = daq.generateWaveform("white", daq.samplerate, frequency=1)
 
-# Keep track of power and phase
-powers = np.zeros_like(freqs)
-phases = np.zeros_like(freqs)
+# Write to channel AO0, read on channel AI0, AI1
+signalOut, signalIn = daq.readwrite(white, ["AI0", "AI1"], "AO0")
 
+# Create Bode() instance
+bode = Bode(daq.samplerate, signalOut, signalIn)
+freqs, welchIn, welchOut = bode.getWelchSpectrum()
+
+plotBode(2 * np.pi * freqs, welchOut, np.zeros_like(welchOut))
 
 # Measure over range of frequencies
-for i, freq in enumerate(freqs):
-    print(freq)
-
-    # Create sinusoidal waveform
-    timeArray, signalWrite = daq.generateWaveform("sine", daq.samplerate, frequency=freq)
-
-    # Write to channel AO0 and read on channel AI0
-    signalOut, signalIn = daq.readwrite(signalWrite, ["AI0", "AI1"], "AO0")
-
-    # Create Bode() instance
-    bode = Bode(daq.samplerate, signalOut, signalIn)
-
-    # Get power and phase of freq, with a bandwidth delta=1
-    power = bode.getPower(freq, 1)
-    phase = bode.getPhase(freq, 0)
-
-    # Save power and phase of freq.
-    powers[i] = power
-    phases[i] = phase
-
-# Plot the bode plots
-plotBode(2 * np.pi * freqs, np.sqrt(powers), phases)
+# for i, freq in enumerate(freqs):
+#     print(freq)
+# 
+#     # Create sinusoidal waveform
+#     timeArray, signalWrite = daq.generateWaveform("sine", daq.samplerate, frequency=freq)
+# 
+#     # Write to channel AO0 and read on channel AI0
+#     signalOut, signalIn = daq.readwrite(signalWrite, ["AI0", "AI1"], "AO0")
+# 
+#     # Create Bode() instance
+#     bode = Bode(daq.samplerate, signalOut, signalIn)
+# 
+#     # Get power and phase of freq, with a bandwidth delta=1
+#     power = bode.getPower(freq, 1)
+#     phase = bode.getPhase(freq, 0)
+# 
+#     # Save power and phase of freq.
+#     powers[i] = power
+#     phases[i] = phase
+# 
+# # Plot the bode plots
+# plotBode(2 * np.pi * freqs, np.sqrt(powers), phases)

--- a/examples/spectrumSimulation.py
+++ b/examples/spectrumSimulation.py
@@ -6,30 +6,70 @@ the Bode() class to extract information for the bode plots
 import numpy as np
 from span.bode import Bode, plotBode
 from scipy.signal import lsim, TransferFunction
+from span.daq import MyDAQ
+from tqdm import tqdm
+
+# Create daq object
+daq = MyDAQ()
+daq.samplerate = 200_000
+daq.name = "myDAQ1"
+print(daq)
 
 # Samplerate and time of simulation
 rate = 200_000
-samples = 600_000
-timeArray = np.linspace(0, samples / rate, samples)
+T = 2
 
 # Create lowpass filter transfer function
 wres = 1000
-H = TransferFunction([0, wres], [1, wres])
+Transfer = TransferFunction([0, wres], [1, wres])
 Hfunc = lambda w: wres / (wres + 1j * w)
 
+
+# =============================================================================
+# = There are two methods to measure the transfer function using SPAN         =
+# = The first method is quick but less accurate, and uses a white noise       =
+# = spectrum to immediately determine the transfer function                   =
+# =============================================================================
+
+# Generate array of white noise
+timeArray, white = MyDAQ.generateWaveform("white", rate, 1, duration=T)
+
+# Write to channel AO0, read on channel AI0, AI1
+signalOut = lsim(Transfer, white, timeArray)[1]
+
+# Create Bode() instance and extract transfer function
+bode = Bode(daq.samplerate, signalOut, white)
+freqs, H = bode.getTransfer(nperseg=int(white.size / 10))
+
+
+# Analytic solution of transfer function
+analytic = Hfunc(2 * np.pi * freqs)
+
+# Plot transfer function
+plotBode(2*np.pi*freqs, np.abs(H), np.angle(H), analytic=analytic,
+         xlim=(10, 1e5), mag_ylim=(-60, 10))
+
+
+# =============================================================================
+# = There are two methods to measure the transfer function using SPAN         =
+# = The second method is slow but more accurate, and uses a sweep over        =
+# = different frequencies to determine the transfer function at each          =
+# = frequency individually                                                    =
+# =============================================================================
+
+
 # Run simulation in the domain [1Hz, 100kHz)
-freqs = np.logspace(0, 5, 50)
+freqs = np.logspace(1, 4, 50)
 
 # Keep track of (simulated) power and phase
 powers = np.zeros_like(freqs)
 phases = np.zeros_like(freqs)
 
 # Run simulation over range of frequencies
-for i, freq in enumerate(freqs):
-    print(freq)
+for i, freq in enumerate(tqdm(freqs)):
     # Input is simple sine, simulate output
-    signalIn = np.sin(2 * np.pi * freq * timeArray)
-    signalOut = lsim(H, signalIn, timeArray)[1]
+    timeArray, signalIn = MyDAQ.generateWaveform("sine", rate, freq, duration=T)
+    signalOut = lsim(Transfer, signalIn, timeArray)[1]
 
     # Create Bode() instance
     bode = Bode(rate, signalOut, signalIn)
@@ -41,9 +81,58 @@ for i, freq in enumerate(freqs):
     # Save power and phase of freq.
     powers[i] = power
     phases[i] = phase
-
+    
+    
 # Analytic solution of transfer function
 analytic = Hfunc(2 * np.pi * freqs)
 
 # Plot the bode plots
 plotBode(2 * np.pi * freqs, np.sqrt(powers), phases, analytic=analytic)
+
+
+# =============================================================================
+# = There are two methods to measure the transfer function using SPAN         =
+# = The second method is slow but more accurate, and uses a sweep over        =
+# = different frequencies to determine the transfer function at each          =
+# = frequency individually                                                    =
+# = Here, we are using the `getTranfer` function of SPAN.bode, which          =
+# = returns the Welch power spectrum. We thus have to extract only at         =
+# = those points closest to the frequency of interest.                        =
+# = This and the previous method are equivalent.                              =
+# =============================================================================
+
+
+# Run simulation in the domain [1Hz, 100kHz)
+freqs = np.logspace(1, 4, 50)
+
+# Keep track of (simulated) magnitude and phase
+mags = np.zeros_like(freqs)
+phases = np.zeros_like(freqs)
+
+# Run simulation over range of frequencies
+for i, freq in enumerate(tqdm(freqs)):
+    # Input is simple sine, simulate output
+    timeArray, signalIn = MyDAQ.generateWaveform("sine", rate, freq, duration=T)
+    signalOut = lsim(Transfer, signalIn, timeArray)[1]
+
+    # Create Bode() instance
+    bode = Bode(rate, signalOut, signalIn)
+
+    # Get power and phase of freq, with a bandwidth delta=1
+    Hfreqs, H = bode.getTransfer(nperseg = int(signalIn.size) / 10)
+    index = np.argmin(abs(Hfreqs - freq))
+    
+    # plotBode(2 * np.pi * freqs, np.abs(H), np.angle(H))
+    
+    mag = abs(H)[index]
+    phase = np.angle(H)[index]
+    # Save power and phase of freq.
+    mags[i] = mag
+    phases[i] = phase
+    
+    
+# Analytic solution of transfer function
+analytic = Hfunc(2 * np.pi * freqs)
+
+# Plot the bode plots
+plotBode(2 * np.pi * freqs, mags, phases, analytic=analytic)

--- a/examples/spectrumSimulation.py
+++ b/examples/spectrumSimulation.py
@@ -46,8 +46,14 @@ freqs, H = bode.getTransfer(nperseg=int(white.size / 10))
 analytic = Hfunc(2 * np.pi * freqs)
 
 # Plot transfer function
-plotBode(2*np.pi*freqs, np.abs(H), np.angle(H), analytic=analytic,
-         xlim=(10, 1e5), mag_ylim=(-60, 10))
+plotBode(
+    2 * np.pi * freqs,
+    np.abs(H),
+    np.angle(H),
+    analytic=analytic,
+    xlim=(10, 1e5),
+    mag_ylim=(-60, 10),
+)
 
 
 # =============================================================================
@@ -81,8 +87,8 @@ for i, freq in enumerate(tqdm(freqs)):
     # Save power and phase of freq.
     powers[i] = power
     phases[i] = phase
-    
-    
+
+
 # Analytic solution of transfer function
 analytic = Hfunc(2 * np.pi * freqs)
 
@@ -119,18 +125,18 @@ for i, freq in enumerate(tqdm(freqs)):
     bode = Bode(rate, signalOut, signalIn)
 
     # Get power and phase of freq, with a bandwidth delta=1
-    Hfreqs, H = bode.getTransfer(nperseg = int(signalIn.size) / 10)
+    Hfreqs, H = bode.getTransfer(nperseg=int(signalIn.size) / 10)
     index = np.argmin(abs(Hfreqs - freq))
-    
+
     # plotBode(2 * np.pi * freqs, np.abs(H), np.angle(H))
-    
+
     mag = abs(H)[index]
     phase = np.angle(H)[index]
     # Save power and phase of freq.
     mags[i] = mag
     phases[i] = phase
-    
-    
+
+
 # Analytic solution of transfer function
 analytic = Hfunc(2 * np.pi * freqs)
 

--- a/setup.py
+++ b/setup.py
@@ -13,5 +13,6 @@ setup(
         "scipy",
         "nidaqmx",
         "matplotlib",
+        "tqdm",
     ],
 )

--- a/span/bode.py
+++ b/span/bode.py
@@ -40,8 +40,8 @@ class Bode:
 
     @staticmethod
     def restrictPiPi(angle):
-        return np.mod(angle + np.pi, 2*np.pi) - np.pi
-    
+        return np.mod(angle + np.pi, 2 * np.pi) - np.pi
+
     def getTransfer(self, nperseg: int = 1024) -> np.ndarray:
         """
         Calculate the transfer function using Welch's method.
@@ -54,15 +54,17 @@ class Bode:
         equivalent to calling `getPower` and `getPhase`.
         """
         if self.voltageIn is not None:
-        # Compute cross power spectral density (CSD) and power spectral density (PSD)
-            freqs, Pxy = csd(self.voltageIn, self.voltageOut, fs=self.samplerate, nperseg=nperseg)
+            # Compute cross power spectral density (CSD) and power spectral density (PSD)
+            freqs, Pxy = csd(
+                self.voltageIn, self.voltageOut, fs=self.samplerate, nperseg=nperseg
+            )
             _, Pxx = welch(self.voltageIn, fs=self.samplerate, nperseg=nperseg)
             H = Pxy / Pxx
         else:
             print("No input given; cannot calculate phase information.")
             print("Will return power spectral density of output instead.")
             freqs, H = welch(self.voltageOut, fs=self.samplerate, nperseg=nperseg)
-        
+
         return freqs, H
 
     def getPower(self, f: float, delta: float) -> float:
@@ -120,31 +122,48 @@ def plotBode(
     phase: np.ndarray,
     save: str = None,
     analytic: np.ndarray = None,
-    **kwargs
+    **kwargs,
 ) -> None:
 
     # Use GridSpec to nicely center subplots
     gs = GridSpec(2, 4)
 
     # Create figure and axes
-    fig = plt.figure(figsize=(10,7))
+    fig = plt.figure(figsize=(10, 7))
     magAx = fig.add_subplot(gs[0, :2])
     phaseAx = fig.add_subplot(gs[0, 2:])
     polarAx = fig.add_subplot(gs[1, 1:3], projection="polar")
-    
+
     # If provided, convert magnitude error to decibels
     if not (kwargs.get("merr") is None):
         logErr = 20 / np.log(10) * kwargs.get("merr") / abs(mag)
     else:
         logErr = None
-    
+
     # Plot data
-    magAx.errorbar(freqs, 20 * np.log10(abs(mag)), yerr=logErr, 
-                   markersize=4, fmt=".", c="k", label="Measured", zorder=0)
-    phaseAx.errorbar(freqs, phase, yerr=kwargs.get("perr"), 
-                     markersize=4, fmt=".", c="k", zorder=0)
-    polarAx.errorbar(phase, mag, xerr=kwargs.get("perr"), yerr=kwargs.get("merr"), 
-                     markersize=4, fmt=".", c="k", zorder=0)
+    magAx.errorbar(
+        freqs,
+        20 * np.log10(abs(mag)),
+        yerr=logErr,
+        markersize=4,
+        fmt=".",
+        c="k",
+        label="Measured",
+        zorder=0,
+    )
+    phaseAx.errorbar(
+        freqs, phase, yerr=kwargs.get("perr"), markersize=4, fmt=".", c="k", zorder=0
+    )
+    polarAx.errorbar(
+        phase,
+        mag,
+        xerr=kwargs.get("perr"),
+        yerr=kwargs.get("merr"),
+        markersize=4,
+        fmt=".",
+        c="k",
+        zorder=0,
+    )
 
     # Add labels
     magAx.set_xlabel("Frequency [rad s$^{-1}$]")
@@ -158,7 +177,7 @@ def plotBode(
     magAx.grid(alpha=0.5)
     phaseAx.grid(alpha=0.5)
     polarAx.grid(alpha=0.5)
-    
+
     # Add analytic if provided
     if not (analytic is None):
         magAx.plot(freqs, 20 * np.log10(abs(analytic)), c="r", label="Analytic")
@@ -166,11 +185,11 @@ def plotBode(
         polarAx.plot(np.angle(analytic), abs(analytic), c="r")
 
         magAx.legend()
-    
+
     # Convert to logarithmic axes
     magAx.set_xscale("log")
     phaseAx.set_xscale("log")
-    
+
     # Set limits if provided
     kwargs.get("xlim") and magAx.set_xlim(kwargs["xlim"])
     kwargs.get("xlim") and phaseAx.set_xlim(kwargs["xlim"])

--- a/span/bode.py
+++ b/span/bode.py
@@ -3,6 +3,7 @@ import numpy as np
 from matplotlib import pyplot as plt
 from matplotlib.gridspec import GridSpec
 from scipy.integrate import trapezoid
+from scipy.signal import welch
 
 
 @dataclass
@@ -45,6 +46,16 @@ class Bode:
             angle += 2 * np.pi
         return angle
     
+    def getWelchSpectrum(self, nperseg: int = 1024) -> np.ndarray:
+        if self.voltageIn is not None:
+            __, welchIn = welch(self.voltageIn, nperseg = nperseg)
+        else:
+            welchIn = 1.0
+
+        freqs, welchOut = welch(self.voltageOut, nperseg = nperseg)
+
+        return freqs, welchIn, welchOut
+
     def getPower(self, f: float, delta: float) -> float:
         """
         Calculate the power (ratio) using Parserval theorem

--- a/span/bode.py
+++ b/span/bode.py
@@ -3,7 +3,7 @@ import numpy as np
 from matplotlib import pyplot as plt
 from matplotlib.gridspec import GridSpec
 from scipy.integrate import trapezoid
-from scipy.signal import welch
+from scipy.signal import welch, csd
 
 
 @dataclass
@@ -46,15 +46,28 @@ class Bode:
             angle += 2 * np.pi
         return angle
     
-    def getWelchSpectrum(self, nperseg: int = 1024) -> np.ndarray:
+    def getTransfer(self, nperseg: int = 1024) -> np.ndarray:
+        """
+        Calculate the transfer function using Welch's method.
+        If `voltageIn` is white noise, this returns the full transfer function.
+        If `voltageIn` is coloured noise (1/f^n), this returns the uncorrected
+        full transfer function.
+        If `voltageIn` is sinusoidal, the return is only physical for the input
+        frequency, and post-processing care should be taken to extract from the
+        return only the transfer function at this input frequency. This is
+        equivalent to calling `getPower` and `getPhase`.
+        """
         if self.voltageIn is not None:
-            __, welchIn = welch(self.voltageIn, nperseg = nperseg)
+        # Compute cross power spectral density (CSD) and power spectral density (PSD)
+            freqs, Pxy = csd(self.voltageIn, self.voltageOut, fs=self.samplerate, nperseg=nperseg)
+            _, Pxx = welch(self.voltageIn, fs=self.samplerate, nperseg=nperseg)
+            H = Pxy / Pxx
         else:
-            welchIn = 1.0
-
-        freqs, welchOut = welch(self.voltageOut, nperseg = nperseg)
-
-        return freqs, welchIn, welchOut
+            print("No input given; cannot calculate phase information.")
+            print("Will return power spectral density of output instead.")
+            freqs, H = welch(self.voltageOut, fs=self.samplerate, nperseg=nperseg)
+        
+        return freqs, H
 
     def getPower(self, f: float, delta: float) -> float:
         """
@@ -136,15 +149,11 @@ def plotBode(
     polarAx.set_xlabel("$\phi$")
     polarAx.set_ylabel("$\omega$")
 
-    # Convert to logarithmic axes
-    magAx.set_xscale("log")
-    phaseAx.set_xscale("log")
-
     # Add grid
     magAx.grid(alpha=0.5)
     phaseAx.grid(alpha=0.5)
     polarAx.grid(alpha=0.5)
-
+    
     # Add analytic if provided
     if not (analytic is None):
         magAx.plot(freqs, 20 * np.log10(abs(analytic)), c="r", label="Analytic")
@@ -152,6 +161,16 @@ def plotBode(
         polarAx.plot(np.angle(analytic), abs(analytic), c="r")
 
         magAx.legend()
+    
+    # Convert to logarithmic axes
+    magAx.set_xscale("log")
+    phaseAx.set_xscale("log")
+    
+    # Set limits if provided
+    kwargs.get("xlim") and magAx.set_xlim(kwargs["xlim"])
+    kwargs.get("xlim") and phaseAx.set_xlim(kwargs["xlim"])
+    kwargs.get("mag_ylim") and magAx.set_ylim(kwargs["mag_ylim"])
+    kwargs.get("phase_ylim") and phaseAx.set_ylim(kwargs["phase_ylim"])
 
     plt.tight_layout()
     plt.show()

--- a/span/bode.py
+++ b/span/bode.py
@@ -40,11 +40,7 @@ class Bode:
 
     @staticmethod
     def restrictPiPi(angle):
-        if angle > np.pi:
-            angle -= 2 * np.pi
-        if angle < -np.pi:
-            angle += 2 * np.pi
-        return angle
+        return np.mod(angle + np.pi, 2*np.pi) - np.pi
     
     def getTransfer(self, nperseg: int = 1024) -> np.ndarray:
         """
@@ -135,11 +131,20 @@ def plotBode(
     magAx = fig.add_subplot(gs[0, :2])
     phaseAx = fig.add_subplot(gs[0, 2:])
     polarAx = fig.add_subplot(gs[1, 1:3], projection="polar")
-
+    
+    # If provided, convert magnitude error to decibels
+    if not (kwargs.get("merr") is None):
+        logErr = 20 / np.log(10) * kwargs.get("merr") / abs(mag)
+    else:
+        logErr = None
+    
     # Plot data
-    magAx.scatter(freqs, 20 * np.log10(abs(mag)), s=4, c="k", label="Measured")
-    phaseAx.scatter(freqs, phase, s=4, c="k")
-    polarAx.scatter(phase, mag, s=4, c="k")
+    magAx.errorbar(freqs, 20 * np.log10(abs(mag)), yerr=logErr, 
+                   markersize=4, fmt=".", c="k", label="Measured", zorder=0)
+    phaseAx.errorbar(freqs, phase, yerr=kwargs.get("perr"), 
+                     markersize=4, fmt=".", c="k", zorder=0)
+    polarAx.errorbar(phase, mag, xerr=kwargs.get("perr"), yerr=kwargs.get("merr"), 
+                     markersize=4, fmt=".", c="k", zorder=0)
 
     # Add labels
     magAx.set_xlabel("Frequency [rad s$^{-1}$]")

--- a/span/daq.py
+++ b/span/daq.py
@@ -169,7 +169,7 @@ class MyDAQ:
         samplerate: int
             Samplerate with which to sample waveform.
         frequency : int or float
-            Frequency of the waveform.
+            Frequency of the waveform. Ignored if `function` is "white".
         amplitude : int or float, optional
             Amplitude of the waveform in volts. The default is 1.
         phase : int or float, optional

--- a/span/daq.py
+++ b/span/daq.py
@@ -211,6 +211,8 @@ class MyDAQ:
                 return lambda x, A, f, p: A * sawtooth(2 * np.pi * f * x + p, width=0)
             case "triangle":
                 return lambda x, A, f, p: A * sawtooth(2 * np.pi * f * x + p, width=0.5)
+            case "white":
+                return lambda x, A, f, p: np.random.normal(0, A, x.shape)
             case _:
                 raise ValueError(f"{function} is not a recognized wavefront form")
 


### PR DESCRIPTION
Added the option to use the Welch PSD to calculate transfer functions.

* Added new function that calculates transfer function using `scipy.signal.welch` and `scipy.signal.csd`
* Updated `plotBode`
    * Added limits to axes
    * Added option to plot errors
* Updated examples
    * Now showcases using white noise as measuring method
* Updated install requirements
    * Now requires `tqdm` to run the examples
* Added `white` to `generateWaveform` to generate white noise
    * `amplitude` or `A` will be used as standard deviation $\sigma$ in `numpy.random.normal`